### PR TITLE
Fix electron/yarn subdependency and eslint/prettier errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-color": "^2.14.1",
     "react-dom": "^16.4.2",
     "react-dropdown": "^1.6.2",
-    "source-map-support": "^0.5.5"
+    "source-map-support": "^0.5.5",
+    "tweetnacl": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -1,11 +1,10 @@
 export default {
-    firmware:
-`Could not communicate with your Model01.
+  firmware: `Could not communicate with your Model01.
 
 This could be because your firmware is out of date.
 Flash with updated firmware from https://github.com/keyboardio/Model01-Firmware
 
 If you have a customized sketch take a look at
 https://github.com/keyboardio/Model01-Firmware/pull/65/files to see how to manually update.`,
-    noKeySelected: `Please click on a key to select one, then enter the keycode for that key and click 'Apply'`
+  noKeySelected: `Please click on a key to select one, then enter the keycode for that key and click 'Apply'`
 };

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -51,11 +51,11 @@ class App extends React.Component {
 
   onKeyChange(layer, keyIndex, value) {
     if (keyIndex === -1) {
-        console.warn(ErrorMessages.noKeySelected);
-        return;
+      console.warn(ErrorMessages.noKeySelected); // eslint-disable-line
+      return;
     }
 
-    this.setState((state, props) => {
+    this.setState(state => {
       let keymap = state.keymap.slice();
       keymap[layer][keyIndex] = this.displayTransformer.parse(value);
       return keymap;
@@ -72,14 +72,17 @@ class App extends React.Component {
     event.preventDefault();
 
     this.focus.close();
-    this.focus.open(Model01).then(port => {
-      this.setState({ device: port });
-      this.focus.command("keymap").then(keymap => {
-        this.setState({ keymap: keymap });
+    this.focus
+      .open(Model01)
+      .then(port => {
+        this.setState({ device: port });
+        this.focus.command("keymap").then(keymap => {
+          this.setState({ keymap: keymap });
+        });
+      })
+      .catch(() => {
+        console.log(ErrorMessages.firmware); // eslint-disable-line
       });
-    }).catch((error) => {
-        console.log(ErrorMessages.firmware)
-    });
   }
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11234,6 +11234,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+tweetnacl@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
+  integrity sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
Add `tweetnacl` package explicitly to stop Yarn error with Electron.

Fix eslint and prettier errors.