### PR TITLE
Do not pop up the DevTools by default

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -34,10 +34,6 @@ async function createMainWindow() {
   });
 
   if (isDevelopment) {
-    window.webContents.openDevTools();
-  }
-
-  if (isDevelopment) {
     window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`);
   } else {
     window.loadURL(

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -3,21 +3,21 @@
 exports[`renders without crashing 1`] = `
 <div>
   <main
-    class="KeyboardSelect-main-89"
+    class="KeyboardSelect-main-96"
   >
     <div
-      class="MuiPaper-root-96 MuiPaper-elevation2-100 MuiPaper-rounded-97 KeyboardSelect-paper-90"
+      class="MuiPaper-root-104 MuiPaper-elevation2-108 MuiPaper-rounded-105 KeyboardSelect-paper-97"
     >
       <a
-        class="MuiBadge-root-123"
+        class="MuiBadge-root-131"
         href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
       >
         <div
-          class="MuiAvatar-root-129 MuiAvatar-colorDefault-130 KeyboardSelect-avatar-91"
+          class="MuiAvatar-root-137 MuiAvatar-colorDefault-138 KeyboardSelect-avatar-98"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-132"
+            class="MuiSvgIcon-root-140"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -32,11 +32,11 @@ exports[`renders without crashing 1`] = `
           </svg>
         </div>
         <span
-          class="MuiBadge-badge-124 KeyboardSelect-bugReport-94 MuiBadge-colorPrimary-125"
+          class="MuiBadge-badge-132 KeyboardSelect-bugReport-101 MuiBadge-colorPrimary-133"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-132 KeyboardSelect-bugReportIcon-95"
+            class="MuiSvgIcon-root-140 KeyboardSelect-bugReportIcon-102"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -52,35 +52,57 @@ exports[`renders without crashing 1`] = `
         </span>
       </a>
       <button
-        class="MuiButtonBase-root-167 MuiButton-root-141 MuiButton-contained-152 MuiButton-containedPrimary-153 MuiButton-raised-155 MuiButton-raisedPrimary-156 MuiButton-fullWidth-166"
+        class="MuiButtonBase-root-175 MuiButton-root-149 MuiButton-contained-160 MuiButton-containedPrimary-161 MuiButton-raised-163 MuiButton-raisedPrimary-164 MuiButton-fullWidth-174"
         tabindex="0"
         type="button"
       >
         <span
-          class="MuiButton-label-142"
+          class="MuiButton-label-150"
         >
           Connect
         </span>
         <span
-          class="MuiTouchRipple-root-170"
+          class="MuiTouchRipple-root-184"
         />
       </button>
     </div>
     <div
-      class="KeyboardSelect-exit-92"
+      class="KeyboardSelect-exit-99"
     >
       <button
-        class="MuiButtonBase-root-167 MuiButton-root-141 MuiButton-text-143 MuiButton-flat-146"
+        class="MuiButtonBase-root-175 MuiButton-root-149 MuiButton-text-151 MuiButton-flat-154"
         tabindex="0"
         type="button"
       >
         <span
-          class="MuiButton-label-142"
+          class="MuiButton-label-150"
         >
           Exit
         </span>
         <span
-          class="MuiTouchRipple-root-170"
+          class="MuiTouchRipple-root-184"
+        />
+      </button>
+    </div>
+    <div
+      class="MuiBottomNavigation-root-178 KeyboardSelect-bottom-103"
+    >
+      <button
+        class="MuiButtonBase-root-175 MuiBottomNavigationAction-root-179"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiBottomNavigationAction-wrapper-182"
+        >
+          <span
+            class="MuiBottomNavigationAction-label-183"
+          >
+            Developer Tools
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root-184"
         />
       </button>
     </div>

--- a/src/renderer/components/KeyboardSelect.js
+++ b/src/renderer/components/KeyboardSelect.js
@@ -21,10 +21,12 @@ import Electron from "electron";
 
 import Avatar from "@material-ui/core/Avatar";
 import Badge from "@material-ui/core/Badge";
+import BottomNavigation from "@material-ui/core/BottomNavigation";
+import BottomNavigationAction from "@material-ui/core/BottomNavigationAction";
 import Button from "@material-ui/core/Button";
 import BugReportIcon from "@material-ui/icons/BugReport";
-import CssBaseline from "@material-ui/core/CssBaseline";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import CssBaseline from "@material-ui/core/CssBaseline";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
@@ -81,6 +83,11 @@ const styles = theme => ({
   bugReportIcon: {
     width: "16px",
     height: "16px"
+  },
+  bottom: {
+    position: "absolute",
+    bottom: theme.spacing.unit * 2,
+    right: theme.spacing.unit * 2
   }
 });
 
@@ -152,6 +159,16 @@ class KeyboardSelect extends React.Component {
 
   exit = () => {
     Electron.remote.app.exit(0);
+  };
+
+  toggleDevTools = () => {
+    const webContents = Electron.remote.getCurrentWebContents();
+
+    if (webContents.isDevToolsOpened()) {
+      webContents.closeDevTools();
+    } else {
+      webContents.openDevTools();
+    }
   };
 
   render() {
@@ -236,6 +253,13 @@ class KeyboardSelect extends React.Component {
         <div className={classes.exit}>
           <Button onClick={this.exit}>Exit</Button>
         </div>
+        <BottomNavigation
+          showLabels
+          onChange={this.toggleDevTools}
+          className={classes.bottom}
+        >
+          <BottomNavigationAction label="Developer Tools" />
+        </BottomNavigation>
       </main>
     );
   }

--- a/src/renderer/components/Settings.js
+++ b/src/renderer/components/Settings.js
@@ -17,7 +17,11 @@
 
 import React from "react";
 import PropTypes from "prop-types";
+import Electron from "electron";
 
+import FormGroup from "@material-ui/core/FormGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Switch from "@material-ui/core/Switch";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
@@ -32,17 +36,50 @@ const styles = theme => ({
 });
 
 class Settings extends React.Component {
+  state = {
+    devTools: false
+  };
+
+  componentDidMount() {
+    const webContents = Electron.remote.getCurrentWebContents();
+    this.setState({ devTools: webContents.isDevToolsOpened() });
+    webContents.on("devtools-opened", () => {
+      this.setState({ devTools: true });
+    });
+    webContents.on("devtools-closed", () => {
+      this.setState({ devTools: false });
+    });
+  }
+
+  toggleDevTools = event => {
+    this.setState({ devTools: event.target.checked });
+    if (event.target.checked) {
+      Electron.remote.getCurrentWebContents().openDevTools();
+    } else {
+      Electron.remote.getCurrentWebContents().closeDevTools();
+    }
+  };
+
   render() {
     const { classes } = this.props;
 
     return (
       <Paper elevation={1} className={classes.root}>
         <Typography variant="h5" component="h3">
-          Chrysalis 0.0.6
+          Settings
         </Typography>
-        <Typography component="p">
-          This is alpha software. Things will break.
-        </Typography>
+        <FormGroup row>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={this.state.devTools}
+                onChange={this.toggleDevTools}
+                value="devtools"
+              />
+            }
+            label="Developer tools"
+          />
+        </FormGroup>
       </Paper>
     );
   }


### PR DESCRIPTION
By default, start with DevTools disabled. Add a toggler onto the KeyboardSelect and Settings components.

Fixes #42.
