### PR TITLE
Speed dial for some persistent actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@material-ui/core": "^3.6.0",
     "@material-ui/icons": "^3.0.1",
+    "@material-ui/lab": "^3.0.0-alpha.25",
     "avrgirl-arduino": "^3.0.0",
     "chrysalis-colormap": "git://github.com/Lepidopterarium/chrysalis-colormap.git#master",
     "chrysalis-focus": "git://github.com/Lepidopterarium/chrysalis-focus.git#master",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -25,11 +25,14 @@ import CoreTransformer from "chrysalis-keymap-transformer-core";
 import { Model01 } from "chrysalis-hardware-keyboardio-model01";
 
 import BugReportIcon from "@material-ui/icons/BugReport";
+import CameraIcon from "@material-ui/icons/Camera";
 import CodeIcon from "@material-ui/icons/Code";
 import SpeedDial from "@material-ui/lab/SpeedDial";
 import SpeedDialIcon from "@material-ui/lab/SpeedDialIcon";
 import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
 import { withStyles } from "@material-ui/core/styles";
+
+import { withSnackbar } from "notistack";
 
 import KeyboardSelect from "./components/KeyboardSelect";
 import Dashboard from "./components/Dashboard";
@@ -107,6 +110,27 @@ class App extends React.Component {
     }));
   };
 
+  saveScreenshot = async () => {
+    const w = Electron.remote.getCurrentWindow(),
+      webContents = Electron.remote.getCurrentWebContents(),
+      fs = Electron.remote.require("fs"),
+      fileName = "chrysalis-" + Date.now().toString() + ".png",
+      devToolsOpen = webContents.isDevToolsOpened();
+
+    if (devToolsOpen) await webContents.closeDevTools();
+
+    setTimeout(() => {
+      w.capturePage(img => {
+        fs.writeFile(fileName, img.toPNG(), () => {
+          this.props.enqueueSnackbar("Screenshot saved to " + fileName, {
+            variant: "success",
+            autoHideDuration: 1000
+          });
+          if (devToolsOpen) webContents.openDevTools();
+        });
+      });
+    }, 1000);
+  };
 
   render() {
     const { classes } = this.props;
@@ -153,10 +177,15 @@ class App extends React.Component {
             tooltipTitle="Report a bug"
             href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
           />
+          <SpeedDialAction
+            icon={<CameraIcon />}
+            tooltipTitle="Save a screenshot"
+            onClick={this.saveScreenshot}
+          />
         </SpeedDial>
       </div>
     );
   }
 }
 
-export default withStyles(styles)(App);
+export default withSnackbar(withStyles(styles)(App));

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -24,8 +24,11 @@ import Colormap from "chrysalis-colormap";
 import CoreTransformer from "chrysalis-keymap-transformer-core";
 import { Model01 } from "chrysalis-hardware-keyboardio-model01";
 
-import Fab from "@material-ui/core/Fab";
+import BugReportIcon from "@material-ui/icons/BugReport";
 import CodeIcon from "@material-ui/icons/Code";
+import SpeedDial from "@material-ui/lab/SpeedDial";
+import SpeedDialIcon from "@material-ui/lab/SpeedDialIcon";
+import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
 import { withStyles } from "@material-ui/core/styles";
 
 import KeyboardSelect from "./components/KeyboardSelect";
@@ -51,7 +54,8 @@ const styles = theme => ({
 
 class App extends React.Component {
   state = {
-    keyboardOpen: false
+    keyboardOpen: false,
+    toolsOpen: false
   };
 
   onKeyboardConnect = async port => {
@@ -89,6 +93,21 @@ class App extends React.Component {
     }
   };
 
+  onToolsOpen = () => {
+    this.setState({ toolsOpen: true });
+  };
+
+  onToolsClose = () => {
+    this.setState({ toolsOpen: false });
+  };
+
+  onToolsToggle = () => {
+    this.setState(state => ({
+      toolsOpen: !state.toolsOpen
+    }));
+  };
+
+
   render() {
     const { classes } = this.props;
 
@@ -104,23 +123,37 @@ class App extends React.Component {
       );
     }
 
-    let toolsButton = null;
-    if (process.env.NODE_ENV !== "production") {
-      toolsButton = (
-        <Fab
-          color="primary"
-          className={classes.tools}
-          onClick={this.toggleDevTools}
-        >
-          <CodeIcon />
-        </Fab>
-      );
-    }
+    const isDevelopment = process.env.NODE_ENV !== "production";
 
     return (
       <div>
         {content}
-        {toolsButton}
+        <SpeedDial
+          ariaLabel="Tools"
+          className={classes.tools}
+          icon={<SpeedDialIcon />}
+          open={this.state.toolsOpen}
+          direction="up"
+          onBlur={this.onToolsClose}
+          onClose={this.onToolsClose}
+          onMouseLeave={this.onToolsClose}
+          onFocus={this.onToolsOpen}
+          onMouseEnter={this.onToolsOpen}
+          onClick={this.onToolsToggle}
+        >
+          {isDevelopment && (
+            <SpeedDialAction
+              icon={<CodeIcon />}
+              tooltipTitle="Toggle DevTools"
+              onClick={this.toggleDevTools}
+            />
+          )}
+          <SpeedDialAction
+            icon={<BugReportIcon />}
+            tooltipTitle="Report a bug"
+            href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
+          />
+        </SpeedDial>
       </div>
     );
   }

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -4,40 +4,149 @@ exports[`renders without crashing 1`] = `
 <div>
   <div>
     <main
-      class="KeyboardSelect-main-101"
+      class="KeyboardSelect-main-116"
     >
       <div
-        class="MuiPaper-root-108 MuiPaper-elevation2-112 MuiPaper-rounded-109 KeyboardSelect-paper-102"
+        class="MuiPaper-root-121 MuiPaper-elevation2-125 MuiPaper-rounded-122 KeyboardSelect-paper-117"
       >
-        <a
-          class="MuiBadge-root-135"
-          href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
+        <div
+          class="MuiAvatar-root-148 MuiAvatar-colorDefault-149 KeyboardSelect-avatar-118"
         >
-          <div
-            class="MuiAvatar-root-141 MuiAvatar-colorDefault-142 KeyboardSelect-avatar-103"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root-151"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"
+            />
+            <path
+              d="M0 0h24v24H0zm0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </div>
+        <button
+          class="MuiButtonBase-root-186 MuiButton-root-160 MuiButton-contained-171 MuiButton-containedPrimary-172 MuiButton-raised-174 MuiButton-raisedPrimary-175 MuiButton-fullWidth-185"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label-161"
+          >
+            Connect
+          </span>
+          <span
+            class="MuiTouchRipple-root-222"
+          />
+        </button>
+      </div>
+      <div
+        class="KeyboardSelect-exit-119"
+      >
+        <button
+          class="MuiButtonBase-root-186 MuiButton-root-160 MuiButton-text-162 MuiButton-flat-165"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label-161"
+          >
+            Exit
+          </span>
+          <span
+            class="MuiTouchRipple-root-222"
+          />
+        </button>
+      </div>
+    </main>
+    <div
+      class="MuiSpeedDial-root-189 MuiSpeedDial-directionUp-191 App-tools-115"
+    >
+      <button
+        aria-controls="Tools-actions"
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-label="Tools"
+        class="MuiButtonBase-root-186 MuiFab-root-197 MuiFab-primary-199 MuiSpeedDial-fab-190"
+        style="transform: scale(1); -webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiFab-label-198"
+        >
+          <span
+            class="MuiSpeedDialIcon-root-207"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-144"
+              class="MuiSvgIcon-root-151 MuiSpeedDialIcon-icon-208"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"
             >
               <path
-                d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"
-              />
-              <path
-                d="M0 0h24v24H0zm0 0h24v24H0z"
-                fill="none"
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
               />
             </svg>
-          </div>
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root-222"
+        />
+      </button>
+      <div
+        aria-orientation="vertical"
+        class="MuiSpeedDial-actions-195 MuiSpeedDial-actionsClosed-196 MuiSpeedDial-directionUp-191"
+        id="Tools-actions"
+        role="menu"
+      >
+        <button
+          class="MuiButtonBase-root-186 MuiFab-root-197 MuiFab-sizeSmall-205 MuiSpeedDialAction-button-213 MuiSpeedDialAction-buttonClosed-214"
+          role="menuitem"
+          tabindex="-1"
+          title="Toggle DevTools"
+          type="button"
+        >
           <span
-            class="MuiBadge-badge-136 KeyboardSelect-bugReport-106 MuiBadge-colorPrimary-137"
+            class="MuiFab-label-198"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-144 KeyboardSelect-bugReportIcon-107"
+              class="MuiSvgIcon-root-151"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0V0z"
+                fill="none"
+              />
+              <path
+                d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root-222"
+          />
+        </button>
+        <a
+          class="MuiButtonBase-root-186 MuiFab-root-197 MuiFab-sizeSmall-205 MuiSpeedDialAction-button-213 MuiSpeedDialAction-buttonClosed-214"
+          href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
+          role="menuitem"
+          tabindex="-1"
+          title="Report a bug"
+        >
+          <span
+            class="MuiFab-label-198"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-151"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"
@@ -51,69 +160,12 @@ exports[`renders without crashing 1`] = `
               />
             </svg>
           </span>
+          <span
+            class="MuiTouchRipple-root-222"
+          />
         </a>
-        <button
-          class="MuiButtonBase-root-179 MuiButton-root-153 MuiButton-contained-164 MuiButton-containedPrimary-165 MuiButton-raised-167 MuiButton-raisedPrimary-168 MuiButton-fullWidth-178"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label-154"
-          >
-            Connect
-          </span>
-          <span
-            class="MuiTouchRipple-root-192"
-          />
-        </button>
       </div>
-      <div
-        class="KeyboardSelect-exit-104"
-      >
-        <button
-          class="MuiButtonBase-root-179 MuiButton-root-153 MuiButton-text-155 MuiButton-flat-158"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label-154"
-          >
-            Exit
-          </span>
-          <span
-            class="MuiTouchRipple-root-192"
-          />
-        </button>
-      </div>
-    </main>
-    <button
-      class="MuiButtonBase-root-179 MuiFab-root-182 MuiFab-primary-184 App-tools-100"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="MuiFab-label-183"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root-144"
-          focusable="false"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M0 0h24v24H0V0z"
-            fill="none"
-          />
-          <path
-            d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
-          />
-        </svg>
-      </span>
-      <span
-        class="MuiTouchRipple-root-192"
-      />
-    </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -2,110 +2,118 @@
 
 exports[`renders without crashing 1`] = `
 <div>
-  <main
-    class="KeyboardSelect-main-96"
-  >
-    <div
-      class="MuiPaper-root-104 MuiPaper-elevation2-108 MuiPaper-rounded-105 KeyboardSelect-paper-97"
+  <div>
+    <main
+      class="KeyboardSelect-main-101"
     >
-      <a
-        class="MuiBadge-root-131"
-        href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
+      <div
+        class="MuiPaper-root-108 MuiPaper-elevation2-112 MuiPaper-rounded-109 KeyboardSelect-paper-102"
       >
-        <div
-          class="MuiAvatar-root-137 MuiAvatar-colorDefault-138 KeyboardSelect-avatar-98"
+        <a
+          class="MuiBadge-root-135"
+          href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root-140"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
+          <div
+            class="MuiAvatar-root-141 MuiAvatar-colorDefault-142 KeyboardSelect-avatar-103"
           >
-            <path
-              d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"
-            />
-            <path
-              d="M0 0h24v24H0zm0 0h24v24H0z"
-              fill="none"
-            />
-          </svg>
-        </div>
-        <span
-          class="MuiBadge-badge-132 KeyboardSelect-bugReport-101 MuiBadge-colorPrimary-133"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root-140 KeyboardSelect-bugReportIcon-102"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-144"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"
+              />
+              <path
+                d="M0 0h24v24H0zm0 0h24v24H0z"
+                fill="none"
+              />
+            </svg>
+          </div>
+          <span
+            class="MuiBadge-badge-136 KeyboardSelect-bugReport-106 MuiBadge-colorPrimary-137"
           >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z"
-            />
-          </svg>
-        </span>
-      </a>
-      <button
-        class="MuiButtonBase-root-175 MuiButton-root-149 MuiButton-contained-160 MuiButton-containedPrimary-161 MuiButton-raised-163 MuiButton-raisedPrimary-164 MuiButton-fullWidth-174"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label-150"
-        >
-          Connect
-        </span>
-        <span
-          class="MuiTouchRipple-root-184"
-        />
-      </button>
-    </div>
-    <div
-      class="KeyboardSelect-exit-99"
-    >
-      <button
-        class="MuiButtonBase-root-175 MuiButton-root-149 MuiButton-text-151 MuiButton-flat-154"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label-150"
-        >
-          Exit
-        </span>
-        <span
-          class="MuiTouchRipple-root-184"
-        />
-      </button>
-    </div>
-    <div
-      class="MuiBottomNavigation-root-178 KeyboardSelect-bottom-103"
-    >
-      <button
-        class="MuiButtonBase-root-175 MuiBottomNavigationAction-root-179"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiBottomNavigationAction-wrapper-182"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-144 KeyboardSelect-bugReportIcon-107"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z"
+              />
+            </svg>
+          </span>
+        </a>
+        <button
+          class="MuiButtonBase-root-179 MuiButton-root-153 MuiButton-contained-164 MuiButton-containedPrimary-165 MuiButton-raised-167 MuiButton-raisedPrimary-168 MuiButton-fullWidth-178"
+          tabindex="0"
+          type="button"
         >
           <span
-            class="MuiBottomNavigationAction-label-183"
+            class="MuiButton-label-154"
           >
-            Developer Tools
+            Connect
           </span>
-        </span>
-        <span
-          class="MuiTouchRipple-root-184"
-        />
-      </button>
-    </div>
-  </main>
+          <span
+            class="MuiTouchRipple-root-192"
+          />
+        </button>
+      </div>
+      <div
+        class="KeyboardSelect-exit-104"
+      >
+        <button
+          class="MuiButtonBase-root-179 MuiButton-root-153 MuiButton-text-155 MuiButton-flat-158"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label-154"
+          >
+            Exit
+          </span>
+          <span
+            class="MuiTouchRipple-root-192"
+          />
+        </button>
+      </div>
+    </main>
+    <button
+      class="MuiButtonBase-root-179 MuiFab-root-182 MuiFab-primary-184 App-tools-100"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiFab-label-183"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root-144"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0V0z"
+            fill="none"
+          />
+          <path
+            d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root-192"
+      />
+    </button>
+  </div>
 </div>
 `;

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -164,6 +164,36 @@ exports[`renders without crashing 1`] = `
             class="MuiTouchRipple-root-222"
           />
         </a>
+        <button
+          class="MuiButtonBase-root-186 MuiFab-root-197 MuiFab-sizeSmall-205 MuiSpeedDialAction-button-213 MuiSpeedDialAction-buttonClosed-214"
+          role="menuitem"
+          tabindex="-1"
+          title="Save a screenshot"
+          type="button"
+        >
+          <span
+            class="MuiFab-label-198"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-151"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M9.4 10.5l4.77-8.26C13.47 2.09 12.75 2 12 2c-2.4 0-4.6.85-6.32 2.25l3.66 6.35.06-.1zM21.54 9c-.92-2.92-3.15-5.26-6-6.34L11.88 9h9.66zm.26 1h-7.49l.29.5 4.76 8.25C21 16.97 22 14.61 22 12c0-.69-.07-1.35-.2-2zM8.54 12l-3.9-6.75C3.01 7.03 2 9.39 2 12c0 .69.07 1.35.2 2h7.49l-1.15-2zm-6.08 3c.92 2.92 3.15 5.26 6 6.34L12.12 15H2.46zm11.27 0l-3.9 6.76c.7.15 1.42.24 2.17.24 2.4 0 4.6-.85 6.32-2.25l-3.66-6.35-.93 1.6z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root-222"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/src/renderer/components/Dashboard.js
+++ b/src/renderer/components/Dashboard.js
@@ -19,7 +19,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
-import BugReportIcon from "@material-ui/icons/BugReport";
 import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import CssBaseline from "@material-ui/core/CssBaseline";
@@ -183,16 +182,6 @@ class Dashboard extends React.Component {
           </List>
           <Divider />
           <List>
-            <ListItem
-              component="a"
-              button
-              href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
-            >
-              <ListItemIcon>
-                <BugReportIcon />
-              </ListItemIcon>
-              <ListItemText primary="Report a bug" />
-            </ListItem>
             <ListItem
               button
               selected={this.state.page == "settings"}

--- a/src/renderer/components/KeyboardSelect.js
+++ b/src/renderer/components/KeyboardSelect.js
@@ -21,8 +21,6 @@ import Electron from "electron";
 
 import Avatar from "@material-ui/core/Avatar";
 import Badge from "@material-ui/core/Badge";
-import BottomNavigation from "@material-ui/core/BottomNavigation";
-import BottomNavigationAction from "@material-ui/core/BottomNavigationAction";
 import Button from "@material-ui/core/Button";
 import BugReportIcon from "@material-ui/icons/BugReport";
 import CircularProgress from "@material-ui/core/CircularProgress";
@@ -83,11 +81,6 @@ const styles = theme => ({
   bugReportIcon: {
     width: "16px",
     height: "16px"
-  },
-  bottom: {
-    position: "absolute",
-    bottom: theme.spacing.unit * 2,
-    right: theme.spacing.unit * 2
   }
 });
 
@@ -159,16 +152,6 @@ class KeyboardSelect extends React.Component {
 
   exit = () => {
     Electron.remote.app.exit(0);
-  };
-
-  toggleDevTools = () => {
-    const webContents = Electron.remote.getCurrentWebContents();
-
-    if (webContents.isDevToolsOpened()) {
-      webContents.closeDevTools();
-    } else {
-      webContents.openDevTools();
-    }
   };
 
   render() {
@@ -253,13 +236,6 @@ class KeyboardSelect extends React.Component {
         <div className={classes.exit}>
           <Button onClick={this.exit}>Exit</Button>
         </div>
-        <BottomNavigation
-          showLabels
-          onChange={this.toggleDevTools}
-          className={classes.bottom}
-        >
-          <BottomNavigationAction label="Developer Tools" />
-        </BottomNavigation>
       </main>
     );
   }

--- a/src/renderer/components/KeyboardSelect.js
+++ b/src/renderer/components/KeyboardSelect.js
@@ -20,9 +20,7 @@ import PropTypes from "prop-types";
 import Electron from "electron";
 
 import Avatar from "@material-ui/core/Avatar";
-import Badge from "@material-ui/core/Badge";
 import Button from "@material-ui/core/Button";
-import BugReportIcon from "@material-ui/icons/BugReport";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
@@ -74,13 +72,6 @@ const styles = theme => ({
   },
   error: {
     color: theme.palette.error.dark
-  },
-  bugReport: {
-    margin: theme.spacing.unit * 1.5
-  },
-  bugReportIcon: {
-    width: "16px",
-    height: "16px"
   }
 });
 
@@ -208,17 +199,9 @@ class KeyboardSelect extends React.Component {
       <main className={classes.main}>
         <CssBaseline />
         <Paper className={classes.paper}>
-          <Badge
-            component="a"
-            href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
-            badgeContent={<BugReportIcon className={classes.bugReportIcon} />}
-            color="primary"
-            classes={{ badge: classes.bugReport }}
-          >
-            <Avatar className={classes.avatar}>
-              <KeyboardIcon />
-            </Avatar>
-          </Badge>
+          <Avatar className={classes.avatar}>
+            <KeyboardIcon />
+          </Avatar>
           {port}
           <Button
             disabled={

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,6 +945,15 @@
     "@babel/runtime" "7.0.0"
     recompose "^0.29.0"
 
+"@material-ui/lab@^3.0.0-alpha.25":
+  version "3.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-3.0.0-alpha.25.tgz#36593e2610a4eeb8fcdea6ab453d1b895e44b42e"
+  integrity sha512-3GEGdoU6FnicAM+tbOLyn95YG1Yk8bF71DGaYyqjL8YU7JAsyAlfbYhMxD7m1BBJw3CH6t4Yc2tAPqldv08xoA==
+  dependencies:
+    "@babel/runtime" "7.1.2"
+    classnames "^2.2.5"
+    keycode "^2.1.9"
+
 "@material-ui/utils@^3.0.0-alpha.0":
   version "3.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.0.tgz#506fcaf531a9a8f58a73ff2d3dfaa36c0f238506"


### PR DESCRIPTION
This moves the DevTools toggle and the bugreport link into an always-visible Speed Dial, so that the handling of them can be implemented globally, instead of for every component that needs to access it.

As a bonus, it also adds a dumb screenshot tool.

![chrysalis-1544526976351](https://user-images.githubusercontent.com/17243/49797047-9d150400-fd3e-11e8-8ab2-742d82c33083.png)
