### PR TITLE
Various UI fixes

### DIFF
--- a/src/renderer/components/ColormapEditor.js
+++ b/src/renderer/components/ColormapEditor.js
@@ -178,7 +178,15 @@ class ColormapEditor extends React.Component {
           </Toolbar>
         </AppBar>
         <div className={classes.editor}>
-          {colormap}
+          <div>
+            {colormap}
+            <SaveChangesButton
+              onClick={this.onApply}
+              disabled={!this.state.modified}
+            >
+              Save Changes
+            </SaveChangesButton>
+          </div>
           <Palette
             palette={this.state.palette}
             className={classes.palette}
@@ -186,12 +194,6 @@ class ColormapEditor extends React.Component {
             onColorPick={this.onColorPick}
           />
         </div>
-        <SaveChangesButton
-          onClick={this.onApply}
-          disabled={!this.state.modified}
-        >
-          Save Changes
-        </SaveChangesButton>
       </div>
     );
   }

--- a/src/renderer/components/LayoutEditor.js
+++ b/src/renderer/components/LayoutEditor.js
@@ -20,9 +20,6 @@ import PropTypes from "prop-types";
 
 import AppBar from "@material-ui/core/AppBar";
 import LinearProgress from "@material-ui/core/LinearProgress";
-import Step from "@material-ui/core/Step";
-import StepLabel from "@material-ui/core/StepLabel";
-import Stepper from "@material-ui/core/Stepper";
 import Tab from "@material-ui/core/Tab";
 import Tabs from "@material-ui/core/Tabs";
 import Toolbar from "@material-ui/core/Toolbar";
@@ -69,30 +66,21 @@ class LayoutEditor extends React.Component {
     currentKeyIndex: -1,
     modified: false,
     saving: false,
-    keymap: [],
-    loadingStep: 0
+    keymap: []
   };
   coreTransformer = new CoreTransformer();
 
   scanKeyboard = async () => {
-    let focus = new Focus(),
-      nextStep = async () => {
-        await this.setState(state => ({
-          loadingStep: state.loadingStep + 1
-        }));
-      };
+    let focus = new Focus();
 
     try {
       let roLayers = await focus.command("keymap.roLayers");
       roLayers = parseInt(roLayers) || 0;
-      nextStep();
 
       let defLayer = await focus.command("settings.defaultLayer");
       defLayer = parseInt(defLayer) || 0;
-      nextStep();
 
       let keymap = await focus.command("keymap");
-      nextStep();
 
       this.setState({
         roLayers: roLayers,
@@ -185,17 +173,6 @@ class LayoutEditor extends React.Component {
       return (
         <main>
           <LinearProgress variant="query" />
-          <Stepper activeStep={this.state.loadingStep} alternativeLabel>
-            <Step>
-              <StepLabel>Check the number of read-only layers</StepLabel>
-            </Step>
-            <Step>
-              <StepLabel>Read the default layer index</StepLabel>
-            </Step>
-            <Step>
-              <StepLabel>Read the keymap</StepLabel>
-            </Step>
-          </Stepper>
         </main>
       );
     }

--- a/src/renderer/components/LayoutEditor.js
+++ b/src/renderer/components/LayoutEditor.js
@@ -261,7 +261,15 @@ class LayoutEditor extends React.Component {
           </Toolbar>
         </AppBar>
         <div className={classes.editor}>
-          {layer}
+          <div>
+            {layer}
+            <SaveChangesButton
+              onClick={this.onApply}
+              disabled={!this.state.modified}
+            >
+              Save Changes
+            </SaveChangesButton>
+          </div>
           <div className={classes.editorControls}>
             <KeySelector
               className="select-keycode"
@@ -271,12 +279,6 @@ class LayoutEditor extends React.Component {
             />
           </div>
         </div>
-        <SaveChangesButton
-          onClick={this.onApply}
-          disabled={!this.state.modified}
-        >
-          Save Changes
-        </SaveChangesButton>
       </div>
     );
   }

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -29,7 +29,7 @@ button {
 
 @media (min-width: 1024px) {
     .layer {
-        width: 768px;
+        width: 640px;
     }
 }
 


### PR DESCRIPTION
Moves the "Save changes" button to a better place on both the Colormap and Keymap editors (fixes #50), removes the stepper from the Keymap editor loader (#49), makes the keymap smaller on 1024x768 resolutions (#51).