### PR TITLE
Clicking the speed dial should keep it open

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -58,7 +58,8 @@ const styles = theme => ({
 class App extends React.Component {
   state = {
     keyboardOpen: false,
-    toolsOpen: false
+    toolsOpen: false,
+    toolsClicked: false
   };
 
   onKeyboardConnect = async port => {
@@ -101,12 +102,15 @@ class App extends React.Component {
   };
 
   onToolsClose = () => {
+    if (this.state.toolsClicked) return;
+
     this.setState({ toolsOpen: false });
   };
 
-  onToolsToggle = () => {
+  onToolsClick = () => {
     this.setState(state => ({
-      toolsOpen: !state.toolsOpen
+      toolsOpen: state.toolsClicked ? !state.toolsOpen : true,
+      toolsClicked: !state.toolsClicked
     }));
   };
 
@@ -163,7 +167,7 @@ class App extends React.Component {
           onMouseLeave={this.onToolsClose}
           onFocus={this.onToolsOpen}
           onMouseEnter={this.onToolsOpen}
-          onClick={this.onToolsToggle}
+          onClick={this.onToolsClick}
         >
           {isDevelopment && (
             <SpeedDialAction


### PR DESCRIPTION
When one clicks the speed dial, it should stay open until clicked again, instead of closing whenever the mouse leaves it.

Fixes #52.
