### PR TITLE
Handle early errors gracefully

### DIFF
--- a/src/renderer/Error.js
+++ b/src/renderer/Error.js
@@ -16,28 +16,22 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
-import Electron from "electron";
-import { SnackbarProvider } from "notistack";
 
-// Use this App file for the main Chrysalis app
-import App from "./App";
-import Error from "./Error";
-import "../styles/keymap.css";
-
-// Use the following for the new UI mockup
-//import "../styles/reset.css";
-// import "./mockup/scss/app.scss";
-// import App from "./mockup/components/App";
-
-try {
-  ReactDOM.render(
-    <SnackbarProvider maxSnack={4}>
-      <App />
-    </SnackbarProvider>,
-    document.getElementById("app")
-  );
-} catch (e) {
-  Electron.remote.getCurrentWebContents().openDevTools();
-  ReactDOM.render(<Error error={e} />, document.getElementById("app"));
+class Error extends React.Component {
+  render() {
+    return (
+      <main>
+        <h1>An error occurred!</h1>
+        <p>
+          Please see the errors on the development console, and{" "}
+          <a href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues/new">
+            report the issue
+          </a>
+          .
+        </p>
+      </main>
+    );
+  }
 }
+
+export default Error;


### PR DESCRIPTION
When we encounter an error during startup, display an error page telling the user to see the development console, and to file a bug. This is not ideal, but way better than an empty white screen without any other indication.

Fixes #57,
