### PR TITLE
KeySelector: Disable the modifier controls for now

### DIFF
--- a/src/renderer/components/LayoutEditor/KeySelector.js
+++ b/src/renderer/components/LayoutEditor/KeySelector.js
@@ -146,7 +146,11 @@ const KeyGroupGrid = withStyles(styles)(props => {
     modSelector = (
       <div>
         <Divider variant="middle" />
-        <FormControl component="fieldset" className={props.classes.keygroup}>
+        <FormControl
+          component="fieldset"
+          className={props.classes.keygroup}
+          disabled
+        >
           <GridList cellHeight="auto" cols={2}>
             <GridListTile>
               <FormControlLabel control={<Checkbox />} label="Control" />


### PR DESCRIPTION
When selecting a key, disable the form that would let one select additional modifiers to be pressed with the key. The functionality is not there yet. We'll re-enable them once they function.