### PR TITLE
Fix serial communication on OSX

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -17,6 +17,7 @@
 
 import React from "react";
 import Electron from "electron";
+import { spawn } from "child_process";
 
 import Focus from "chrysalis-focus";
 import Keymap from "chrysalis-keymap";
@@ -91,6 +92,9 @@ class App extends React.Component {
 
     console.log("Connecting to", port.comName);
     await focus.open(port.comName, port.device);
+    if (process.platform == "darwin") {
+      await spawn("stty", ["-f", port.comName, "clocal"]);
+    }
     console.log("Probing for Focus support...");
     let commands = await focus.probe();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,7 +2772,7 @@ chromium-pickle-js@^0.2.0:
 
 "chrysalis-focus@git://github.com/Lepidopterarium/chrysalis-focus.git#master":
   version "0.0.1"
-  resolved "git://github.com/Lepidopterarium/chrysalis-focus.git#947add3795b7566167ae8a3a67ee23b2627dedb8"
+  resolved "git://github.com/Lepidopterarium/chrysalis-focus.git#fb49fbfd030762eeddf8361cc9061c6716461de7"
   dependencies:
     "@babel/cli" "^7.1.0"
     "@babel/core" "7.1.0"


### PR DESCRIPTION
On OSX, we need to set `clocal` on the serial port, do that by spawning `stty` (cheaper than pulling in yet another npm module). This fixes the read timeouts and garbage reading. To fix writes, update to the newest chrysalis-focus, which includes an OSX workaround.

Fixes #65.
