### PR TITLE
onKeyboardConnect: Focus should be optional

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -96,7 +96,12 @@ class App extends React.Component {
       await spawn("stty", ["-f", port.comName, "clocal"]);
     }
     console.log("Probing for Focus support...");
-    let commands = await focus.probe();
+    let commands = await focus.probe;
+    try {
+      commands = await focus.probe();
+    } catch (e) {
+      commands = [];
+    }
 
     this.setState({
       keyboardOpen: true,


### PR DESCRIPTION
Surround the `Focus` probe with a try/catch block, and set `commands` to an empty list if it fails (due to timeout). This should allow one to connect to the keyboard, and flash new, focus-supporting firmware.

Fixes #68.
