### PR TITLE
Dashboard: Default to the keymap page, if available

### DIFF
--- a/src/renderer/components/Dashboard.js
+++ b/src/renderer/components/Dashboard.js
@@ -86,10 +86,14 @@ const styles = theme => ({
 });
 
 class Dashboard extends React.Component {
-  state = {
-    open: false,
-    page: "info"
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      open: false,
+      page: props.pages.keymap ? "keymap" : "info"
+    };
+  }
 
   handleDrawerToggle = () => {
     this.setState({ open: !this.state.open });


### PR DESCRIPTION
If we detected that the keyboard supports keymap editing, default to that page.

Fixes #87.
