### PR TITLE
Turn the FAB SpeedDial into a persistent menu

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -16,7 +16,6 @@
  */
 
 import React from "react";
-import Electron from "electron";
 import { spawn } from "child_process";
 
 import Focus from "@chrysalis-api/focus";
@@ -28,15 +27,7 @@ import { Model01 } from "@chrysalis-api/hardware-keyboardio-model01";
 import usb from "usb";
 import { withSnackbar } from "notistack";
 
-import BugReportIcon from "@material-ui/icons/BugReport";
-import CameraIcon from "@material-ui/icons/Camera";
-import CodeIcon from "@material-ui/icons/Code";
-import SpeedDial from "@material-ui/lab/SpeedDial";
-import SpeedDialIcon from "@material-ui/lab/SpeedDialIcon";
-import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
-import { withStyles } from "@material-ui/core/styles";
-
-import { isDevelopment } from "./config";
+import AppTools from "./components/AppTools";
 import KeyboardSelect from "./components/KeyboardSelect";
 import Dashboard from "./components/Dashboard";
 
@@ -51,19 +42,9 @@ focus.addCommands({
 });
 focus.timeout = 15000;
 
-const styles = theme => ({
-  tools: {
-    position: "fixed",
-    bottom: theme.spacing.unit * 2,
-    right: theme.spacing.unit * 2
-  }
-});
-
 class App extends React.Component {
   state = {
-    keyboardOpen: false,
-    toolsOpen: false,
-    toolsClicked: false
+    keyboardOpen: false
   };
 
   componentDidMount() {
@@ -120,58 +101,7 @@ class App extends React.Component {
     this.setState({ keyboardOpen: false });
   };
 
-  toggleDevTools = () => {
-    const webContents = Electron.remote.getCurrentWebContents();
-
-    if (webContents.isDevToolsOpened()) {
-      webContents.closeDevTools();
-    } else {
-      webContents.openDevTools();
-    }
-  };
-
-  onToolsOpen = () => {
-    this.setState({ toolsOpen: true });
-  };
-
-  onToolsClose = () => {
-    if (this.state.toolsClicked) return;
-
-    this.setState({ toolsOpen: false });
-  };
-
-  onToolsClick = () => {
-    this.setState(state => ({
-      toolsOpen: state.toolsClicked ? !state.toolsOpen : true,
-      toolsClicked: !state.toolsClicked
-    }));
-  };
-
-  saveScreenshot = async () => {
-    const w = Electron.remote.getCurrentWindow(),
-      webContents = Electron.remote.getCurrentWebContents(),
-      fs = Electron.remote.require("fs"),
-      fileName = "chrysalis-" + Date.now().toString() + ".png",
-      devToolsOpen = webContents.isDevToolsOpened();
-
-    if (devToolsOpen) await webContents.closeDevTools();
-
-    setTimeout(() => {
-      w.capturePage(img => {
-        fs.writeFile(fileName, img.toPNG(), () => {
-          this.props.enqueueSnackbar("Screenshot saved to " + fileName, {
-            variant: "success",
-            autoHideDuration: 1000
-          });
-          if (devToolsOpen) webContents.openDevTools();
-        });
-      });
-    }, 1000);
-  };
-
   render() {
-    const { classes } = this.props;
-
     let content;
     if (!this.state.keyboardOpen) {
       content = <KeyboardSelect onConnect={this.onKeyboardConnect} />;
@@ -187,40 +117,10 @@ class App extends React.Component {
     return (
       <div>
         {content}
-        <SpeedDial
-          ariaLabel="Tools"
-          className={classes.tools}
-          icon={<SpeedDialIcon />}
-          open={this.state.toolsOpen}
-          direction="up"
-          onBlur={this.onToolsClose}
-          onClose={this.onToolsClose}
-          onMouseLeave={this.onToolsClose}
-          onFocus={this.onToolsOpen}
-          onMouseEnter={this.onToolsOpen}
-          onClick={this.onToolsClick}
-        >
-          {isDevelopment && (
-            <SpeedDialAction
-              icon={<CodeIcon />}
-              tooltipTitle="Toggle DevTools"
-              onClick={this.toggleDevTools}
-            />
-          )}
-          <SpeedDialAction
-            icon={<BugReportIcon />}
-            tooltipTitle="Report a bug"
-            href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
-          />
-          <SpeedDialAction
-            icon={<CameraIcon />}
-            tooltipTitle="Save a screenshot"
-            onClick={this.saveScreenshot}
-          />
-        </SpeedDial>
+        <AppTools />
       </div>
     );
   }
 }
 
-export default withSnackbar(withStyles(styles)(App));
+export default withSnackbar(App);

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -4,10 +4,10 @@ exports[`renders without crashing 1`] = `
 <div>
   <div>
     <main
-      class="KeyboardSelect-main-135"
+      class="KeyboardSelect-main-134"
     >
       <div
-        class="MuiLinearProgress-root-242 MuiLinearProgress-colorPrimary-243 MuiLinearProgress-query-246 KeyboardSelect-loader-134"
+        class="MuiLinearProgress-root-242 MuiLinearProgress-colorPrimary-243 MuiLinearProgress-query-246 KeyboardSelect-loader-133"
         role="progressbar"
       >
         <div
@@ -18,14 +18,14 @@ exports[`renders without crashing 1`] = `
         />
       </div>
       <div
-        class="MuiPaper-root-141 MuiPaper-elevation2-145 MuiPaper-rounded-142 KeyboardSelect-paper-136"
+        class="MuiPaper-root-140 MuiPaper-elevation2-144 MuiPaper-rounded-141 KeyboardSelect-paper-135"
       >
         <div
-          class="MuiAvatar-root-168 MuiAvatar-colorDefault-169 KeyboardSelect-avatar-137"
+          class="MuiAvatar-root-167 MuiAvatar-colorDefault-168 KeyboardSelect-avatar-136"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-171"
+            class="MuiSvgIcon-root-170"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -40,12 +40,12 @@ exports[`renders without crashing 1`] = `
           </svg>
         </div>
         <button
-          class="MuiButtonBase-root-206 MuiButton-root-180 MuiButton-contained-191 MuiButton-containedPrimary-192 MuiButton-raised-194 MuiButton-raisedPrimary-195 MuiButton-fullWidth-205"
+          class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-contained-190 MuiButton-containedPrimary-191 MuiButton-raised-193 MuiButton-raisedPrimary-194 MuiButton-fullWidth-204"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-label-181"
+            class="MuiButton-label-180"
           >
             Connect
           </span>
@@ -55,15 +55,15 @@ exports[`renders without crashing 1`] = `
         </button>
       </div>
       <div
-        class="KeyboardSelect-bottomButtons-138"
+        class="KeyboardSelect-bottomButtons-137"
       >
         <button
-          class="MuiButtonBase-root-206 MuiButton-root-180 MuiButton-text-182 MuiButton-flat-185"
+          class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-text-181 MuiButton-flat-184"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-label-181"
+            class="MuiButton-label-180"
           >
             Scan devices
           </span>
@@ -72,15 +72,15 @@ exports[`renders without crashing 1`] = `
           />
         </button>
         <div
-          class="KeyboardSelect-exit-139"
+          class="KeyboardSelect-exit-138"
         >
           <button
-            class="MuiButtonBase-root-206 MuiButton-root-180 MuiButton-text-182 MuiButton-flat-185"
+            class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-text-181 MuiButton-flat-184"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiButton-label-181"
+              class="MuiButton-label-180"
             >
               Exit
             </span>
@@ -92,14 +92,14 @@ exports[`renders without crashing 1`] = `
       </div>
     </main>
     <div
-      class="MuiSpeedDial-root-209 MuiSpeedDial-directionUp-211 App-tools-133"
+      class="MuiSpeedDial-root-209 MuiSpeedDial-directionUp-211 AppTools-tools-208"
     >
       <button
         aria-controls="Tools-actions"
         aria-expanded="false"
         aria-haspopup="true"
         aria-label="Tools"
-        class="MuiButtonBase-root-206 MuiFab-root-217 MuiFab-primary-219 MuiSpeedDial-fab-210"
+        class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-primary-219 MuiSpeedDial-fab-210"
         style="transform: scale(1); -webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         tabindex="0"
         type="button"
@@ -112,7 +112,7 @@ exports[`renders without crashing 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-171 MuiSpeedDialIcon-icon-228"
+              class="MuiSvgIcon-root-170 MuiSpeedDialIcon-icon-228"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"
@@ -134,7 +134,7 @@ exports[`renders without crashing 1`] = `
         role="menu"
       >
         <button
-          class="MuiButtonBase-root-206 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
+          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
           role="menuitem"
           tabindex="-1"
           title="Toggle DevTools"
@@ -145,7 +145,7 @@ exports[`renders without crashing 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-171"
+              class="MuiSvgIcon-root-170"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"
@@ -164,7 +164,7 @@ exports[`renders without crashing 1`] = `
           />
         </button>
         <a
-          class="MuiButtonBase-root-206 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
+          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
           href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
           role="menuitem"
           tabindex="-1"
@@ -175,7 +175,7 @@ exports[`renders without crashing 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-171"
+              class="MuiSvgIcon-root-170"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"
@@ -194,7 +194,7 @@ exports[`renders without crashing 1`] = `
           />
         </a>
         <button
-          class="MuiButtonBase-root-206 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
+          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
           role="menuitem"
           tabindex="-1"
           title="Save a screenshot"
@@ -205,7 +205,7 @@ exports[`renders without crashing 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root-171"
+              class="MuiSvgIcon-root-170"
               focusable="false"
               role="presentation"
               viewBox="0 0 24 24"

--- a/src/renderer/__snapshots__/App.test.js.snap
+++ b/src/renderer/__snapshots__/App.test.js.snap
@@ -4,28 +4,28 @@ exports[`renders without crashing 1`] = `
 <div>
   <div>
     <main
-      class="KeyboardSelect-main-134"
+      class="KeyboardSelect-main-105"
     >
       <div
-        class="MuiLinearProgress-root-242 MuiLinearProgress-colorPrimary-243 MuiLinearProgress-query-246 KeyboardSelect-loader-133"
+        class="MuiLinearProgress-root-184 MuiLinearProgress-colorPrimary-185 MuiLinearProgress-query-188 KeyboardSelect-loader-104"
         role="progressbar"
       >
         <div
-          class="MuiLinearProgress-bar-250 MuiLinearProgress-barColorPrimary-251 MuiLinearProgress-bar1Indeterminate-253"
+          class="MuiLinearProgress-bar-192 MuiLinearProgress-barColorPrimary-193 MuiLinearProgress-bar1Indeterminate-195"
         />
         <div
-          class="MuiLinearProgress-bar-250 MuiLinearProgress-barColorPrimary-251 MuiLinearProgress-bar2Indeterminate-256"
+          class="MuiLinearProgress-bar-192 MuiLinearProgress-barColorPrimary-193 MuiLinearProgress-bar2Indeterminate-198"
         />
       </div>
       <div
-        class="MuiPaper-root-140 MuiPaper-elevation2-144 MuiPaper-rounded-141 KeyboardSelect-paper-135"
+        class="MuiPaper-root-111 MuiPaper-elevation2-115 MuiPaper-rounded-112 KeyboardSelect-paper-106"
       >
         <div
-          class="MuiAvatar-root-167 MuiAvatar-colorDefault-168 KeyboardSelect-avatar-136"
+          class="MuiAvatar-root-138 MuiAvatar-colorDefault-139 KeyboardSelect-avatar-107"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-170"
+            class="MuiSvgIcon-root-141"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -40,190 +40,74 @@ exports[`renders without crashing 1`] = `
           </svg>
         </div>
         <button
-          class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-contained-190 MuiButton-containedPrimary-191 MuiButton-raised-193 MuiButton-raisedPrimary-194 MuiButton-fullWidth-204"
+          class="MuiButtonBase-root-176 MuiButton-root-150 MuiButton-contained-161 MuiButton-containedPrimary-162 MuiButton-raised-164 MuiButton-raisedPrimary-165 MuiButton-fullWidth-175"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-label-180"
+            class="MuiButton-label-151"
           >
             Connect
           </span>
           <span
-            class="MuiTouchRipple-root-258"
+            class="MuiTouchRipple-root-200"
           />
         </button>
       </div>
       <div
-        class="KeyboardSelect-bottomButtons-137"
+        class="KeyboardSelect-bottomButtons-108"
       >
         <button
-          class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-text-181 MuiButton-flat-184"
+          class="MuiButtonBase-root-176 MuiButton-root-150 MuiButton-text-152 MuiButton-flat-155"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-label-180"
+            class="MuiButton-label-151"
           >
             Scan devices
           </span>
           <span
-            class="MuiTouchRipple-root-258"
+            class="MuiTouchRipple-root-200"
           />
         </button>
         <div
-          class="KeyboardSelect-exit-138"
+          class="KeyboardSelect-exit-109"
         >
           <button
-            class="MuiButtonBase-root-205 MuiButton-root-179 MuiButton-text-181 MuiButton-flat-184"
+            class="MuiButtonBase-root-176 MuiButton-root-150 MuiButton-text-152 MuiButton-flat-155"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiButton-label-180"
+              class="MuiButton-label-151"
             >
               Exit
             </span>
             <span
-              class="MuiTouchRipple-root-258"
+              class="MuiTouchRipple-root-200"
             />
           </button>
         </div>
       </div>
     </main>
     <div
-      class="MuiSpeedDial-root-209 MuiSpeedDial-directionUp-211 AppTools-tools-208"
+      class="AppTools-tools-179"
     >
       <button
-        aria-controls="Tools-actions"
-        aria-expanded="false"
-        aria-haspopup="true"
-        aria-label="Tools"
-        class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-primary-219 MuiSpeedDial-fab-210"
-        style="transform: scale(1); -webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+        class="MuiButtonBase-root-176 MuiButton-root-150 MuiButton-contained-161 MuiButton-raised-164"
         tabindex="0"
         type="button"
       >
         <span
-          class="MuiFab-label-218"
+          class="MuiButton-label-151"
         >
-          <span
-            class="MuiSpeedDialIcon-root-227"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root-170 MuiSpeedDialIcon-icon-228"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-              />
-            </svg>
-          </span>
+          QA Tools
         </span>
         <span
-          class="MuiTouchRipple-root-258"
+          class="MuiTouchRipple-root-200"
         />
       </button>
-      <div
-        aria-orientation="vertical"
-        class="MuiSpeedDial-actions-215 MuiSpeedDial-actionsClosed-216 MuiSpeedDial-directionUp-211"
-        id="Tools-actions"
-        role="menu"
-      >
-        <button
-          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
-          role="menuitem"
-          tabindex="-1"
-          title="Toggle DevTools"
-          type="button"
-        >
-          <span
-            class="MuiFab-label-218"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root-170"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M0 0h24v24H0V0z"
-                fill="none"
-              />
-              <path
-                d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root-258"
-          />
-        </button>
-        <a
-          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
-          href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
-          role="menuitem"
-          tabindex="-1"
-          title="Report a bug"
-        >
-          <span
-            class="MuiFab-label-218"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root-170"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root-258"
-          />
-        </a>
-        <button
-          class="MuiButtonBase-root-205 MuiFab-root-217 MuiFab-sizeSmall-225 MuiSpeedDialAction-button-233 MuiSpeedDialAction-buttonClosed-234"
-          role="menuitem"
-          tabindex="-1"
-          title="Save a screenshot"
-          type="button"
-        >
-          <span
-            class="MuiFab-label-218"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root-170"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M9.4 10.5l4.77-8.26C13.47 2.09 12.75 2 12 2c-2.4 0-4.6.85-6.32 2.25l3.66 6.35.06-.1zM21.54 9c-.92-2.92-3.15-5.26-6-6.34L11.88 9h9.66zm.26 1h-7.49l.29.5 4.76 8.25C21 16.97 22 14.61 22 12c0-.69-.07-1.35-.2-2zM8.54 12l-3.9-6.75C3.01 7.03 2 9.39 2 12c0 .69.07 1.35.2 2h7.49l-1.15-2zm-6.08 3c.92 2.92 3.15 5.26 6 6.34L12.12 15H2.46zm11.27 0l-3.9 6.76c.7.15 1.42.24 2.17.24 2.4 0 4.6-.85 6.32-2.25l-3.66-6.35-.93 1.6z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root-258"
-          />
-        </button>
-      </div>
     </div>
   </div>
 </div>

--- a/src/renderer/components/AppTools.js
+++ b/src/renderer/components/AppTools.js
@@ -69,12 +69,8 @@ class AppTools extends React.Component {
 
   saveScreenshot = async () => {
     const w = Electron.remote.getCurrentWindow(),
-      webContents = Electron.remote.getCurrentWebContents(),
       fs = Electron.remote.require("fs"),
-      fileName = "chrysalis-" + Date.now().toString() + ".png",
-      devToolsOpen = webContents.isDevToolsOpened();
-
-    if (devToolsOpen) await webContents.closeDevTools();
+      fileName = "chrysalis-" + Date.now().toString() + ".png";
 
     this.closeMenu();
 
@@ -85,7 +81,6 @@ class AppTools extends React.Component {
             variant: "success",
             autoHideDuration: 1000
           });
-          if (devToolsOpen) webContents.openDevTools();
         });
       });
     }, 1000);

--- a/src/renderer/components/AppTools.js
+++ b/src/renderer/components/AppTools.js
@@ -1,0 +1,133 @@
+// -*- mode: js-jsx -*-
+/* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
+ * Copyright (C) 2018  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import Electron from "electron";
+
+import BugReportIcon from "@material-ui/icons/BugReport";
+import CameraIcon from "@material-ui/icons/Camera";
+import CodeIcon from "@material-ui/icons/Code";
+import SpeedDial from "@material-ui/lab/SpeedDial";
+import SpeedDialIcon from "@material-ui/lab/SpeedDialIcon";
+import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
+import { withStyles } from "@material-ui/core/styles";
+
+import { isDevelopment } from "../config";
+
+const styles = theme => ({
+  tools: {
+    position: "fixed",
+    bottom: theme.spacing.unit * 2,
+    right: theme.spacing.unit * 2
+  }
+});
+
+class AppTools extends React.Component {
+  state = {
+    toolsOpen: false,
+    toolsClicked: false
+  };
+
+  toggleDevTools = () => {
+    const webContents = Electron.remote.getCurrentWebContents();
+
+    if (webContents.isDevToolsOpened()) {
+      webContents.closeDevTools();
+    } else {
+      webContents.openDevTools();
+    }
+  };
+
+  onToolsOpen = () => {
+    this.setState({ toolsOpen: true });
+  };
+
+  onToolsClose = () => {
+    if (this.state.toolsClicked) return;
+
+    this.setState({ toolsOpen: false });
+  };
+
+  onToolsClick = () => {
+    this.setState(state => ({
+      toolsOpen: state.toolsClicked ? !state.toolsOpen : true,
+      toolsClicked: !state.toolsClicked
+    }));
+  };
+
+  saveScreenshot = async () => {
+    const w = Electron.remote.getCurrentWindow(),
+      webContents = Electron.remote.getCurrentWebContents(),
+      fs = Electron.remote.require("fs"),
+      fileName = "chrysalis-" + Date.now().toString() + ".png",
+      devToolsOpen = webContents.isDevToolsOpened();
+
+    if (devToolsOpen) await webContents.closeDevTools();
+
+    setTimeout(() => {
+      w.capturePage(img => {
+        fs.writeFile(fileName, img.toPNG(), () => {
+          this.props.enqueueSnackbar("Screenshot saved to " + fileName, {
+            variant: "success",
+            autoHideDuration: 1000
+          });
+          if (devToolsOpen) webContents.openDevTools();
+        });
+      });
+    }, 1000);
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <SpeedDial
+        ariaLabel="Tools"
+        className={classes.tools}
+        icon={<SpeedDialIcon />}
+        open={this.state.toolsOpen}
+        direction="up"
+        onBlur={this.onToolsClose}
+        onClose={this.onToolsClose}
+        onMouseLeave={this.onToolsClose}
+        onFocus={this.onToolsOpen}
+        onMouseEnter={this.onToolsOpen}
+        onClick={this.onToolsClick}
+      >
+        {isDevelopment && (
+          <SpeedDialAction
+            icon={<CodeIcon />}
+            tooltipTitle="Toggle DevTools"
+            onClick={this.toggleDevTools}
+          />
+        )}
+        <SpeedDialAction
+          icon={<BugReportIcon />}
+          tooltipTitle="Report a bug"
+          href="https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues"
+        />
+        <SpeedDialAction
+          icon={<CameraIcon />}
+          tooltipTitle="Save a screenshot"
+          onClick={this.saveScreenshot}
+        />
+      </SpeedDial>
+    );
+  }
+}
+
+export default withStyles(styles)(AppTools);


### PR DESCRIPTION
This turns the FAB SpeedDial into a menu that's always on the lower right corner, and functions like a proper menu.

This is done in a three step process:

- First we extract the Tools speed dial into its own component.
- Then we turn it from a FAB into a Menu.
- Then we make it not toggle DevTools, because that's counter-intuitive.

The end result looks like this:

![chrysalis-1545396871262](https://user-images.githubusercontent.com/17243/50343654-0f000100-0528-11e9-9f03-1672430b1fe7.png)
![chrysalis-1545395602944](https://user-images.githubusercontent.com/17243/50343657-11faf180-0528-11e9-8847-1d24feb7f3e6.png)

Fixes #78.