### PR TITLE
Completely revamped flashing flow

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -46,10 +46,12 @@ class App extends React.Component {
   state = {
     keyboardOpen: false
   };
+  flashing = false;
 
   componentDidMount() {
     usb.on("detach", device => {
       if (!focus.device) return;
+      if (this.flashing) return;
 
       if (
         focus.device.usb.vendorId != device.deviceDescriptor.idVendor ||
@@ -67,6 +69,10 @@ class App extends React.Component {
       }
     });
   }
+
+  toggleFlashing = () => {
+    this.flashing = !this.flashing;
+  };
 
   onKeyboardConnect = async port => {
     focus.close();
@@ -110,6 +116,7 @@ class App extends React.Component {
         <Dashboard
           pages={this.state.supportedPages}
           onDisconnect={this.onKeyboardDisconnect}
+          toggleFlashing={this.toggleFlashing}
         />
       );
     }

--- a/src/renderer/components/Dashboard.js
+++ b/src/renderer/components/Dashboard.js
@@ -122,7 +122,12 @@ class Dashboard extends React.Component {
       page = <Settings />;
     }
     if (this.state.page == "info") {
-      page = <KeyboardInfo onDisconnect={this.disconnect} />;
+      page = (
+        <KeyboardInfo
+          onDisconnect={this.disconnect}
+          toggleFlashing={this.props.toggleFlashing}
+        />
+      );
     }
 
     return (

--- a/src/renderer/components/KeyboardInfo/UploadDialog.js
+++ b/src/renderer/components/KeyboardInfo/UploadDialog.js
@@ -1,0 +1,156 @@
+// -*- mode: js-jsx -*-
+/* chrysalis-bundle-keyboardio -- Chrysalis Bundle for Keyboard.io
+ * Copyright (C) 2018  Keyboardio, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import AvrGirl from "avrgirl-arduino";
+
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import { withStyles } from "@material-ui/core/styles";
+
+import { withSnackbar } from "notistack";
+
+import Focus from "@chrysalis-api/focus";
+
+import SaveChangesButton from "../SaveChangesButton";
+
+const styles = theme => ({
+  dialog: {
+    padding: theme.spacing.unit * 2
+  },
+  p: {
+    marginBottom: theme.spacing.unit * 2
+  }
+});
+
+class UploadDialog extends React.Component {
+  state = {
+    inProgress: false
+  };
+
+  _flashDebug = (message, ...args) => {
+    if (message == "found port on") {
+      this._portName = args[0];
+    }
+    console.log(message, ...args);
+  };
+
+  _flash = () => {
+    let avrgirl = new AvrGirl({
+      board: {
+        name: "Keyboard.io Model 01",
+        baud: 9600,
+        productId: ["0x2300", "0x2301"],
+        protocol: "avr109",
+        signature: new Buffer.from([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e])
+      },
+      debug: this._flashDebug
+    });
+    avrgirl.connection.debug = this._flashDebug;
+
+    return new Promise((resolve, reject) => {
+      avrgirl.flash(this.props.filename, error => {
+        if (error) {
+          avrgirl.connection.serialPort.close();
+          reject(error);
+        } else {
+          setTimeout(() => {
+            resolve();
+          }, 2000);
+        }
+      });
+    });
+  };
+
+  upload = async () => {
+    await this.props.toggleFlashing();
+    await this.setState({ inProgress: true });
+    let focus = new Focus();
+    await focus.close();
+
+    try {
+      await this._flash();
+    } catch (e) {
+      this.props.enqueueSnackbar("Error flashing the firmware", {
+        variant: "error"
+      });
+      this.props.toggleFlashing();
+      this.props.onDisconnect();
+      return;
+    }
+
+    setTimeout(() => {
+      this.props.toggleFlashing();
+      this.props.onSuccess();
+      this.props.onClose();
+    }, 5000);
+  };
+
+  onClose = () => {
+    if (this.state.inProgress) return;
+    return this.props.onClose();
+  };
+
+  render() {
+    const { open, classes } = this.props;
+
+    return (
+      <Dialog
+        onClose={this.onClose}
+        open={open}
+        classes={{ paper: classes.dialog }}
+      >
+        <DialogTitle>{"Upload new firmware?"}</DialogTitle>
+        <DialogContent>
+          <DialogContentText className={classes.p}>
+            {
+              "This will overwrite the firmware already present on the keyboard. But do not worry, updating is safe, you can't brick your keyboard, not even with bad firmware."
+            }
+          </DialogContentText>
+          <DialogContentText className={classes.p}>
+            {"If you wish to proceed, press and hold the "}
+            <kbd>Prog</kbd>
+            {" key on your keyboard, and click the 'Upload' button."}
+          </DialogContentText>
+          <DialogContentText className={classes.p}>
+            {
+              "Once the upload is finished - either successfully or with errors -, you will be taken back to the initial keyboard selection screen. This is normal."
+            }
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={this.onClose}
+            color="primary"
+            disabled={this.state.inProgress}
+          >
+            Cancel
+          </Button>
+          <SaveChangesButton onClick={this.upload} successMessage="Uploaded!">
+            Upload
+          </SaveChangesButton>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+export default withSnackbar(withStyles(styles)(UploadDialog));


### PR DESCRIPTION
When clicking the "Upload" button on the flashing card, instead of flashing right away, a dialog will pop up with some explanatory text about what will happen, and what to expect. This fixes #83.

After flashing is done, we'll fall back to the keyboard selection screen, because reconnecting is not reliable yet. This should fix the white screen after flashing, and as such, this also closes #69.

![screenshot from 2018-12-22 01-26-31](https://user-images.githubusercontent.com/17243/50368411-b3b22b00-0588-11e9-9555-ccf412c6dddf.png)
