### PR TITLE
Flasher: Vastly improved robustness

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -72,6 +72,9 @@ class App extends React.Component {
 
   toggleFlashing = () => {
     this.flashing = !this.flashing;
+    if (!this.flashing) {
+      this.setState({ keyboardOpen: false });
+    }
   };
 
   onKeyboardConnect = async port => {

--- a/src/renderer/components/KeyboardInfo.js
+++ b/src/renderer/components/KeyboardInfo.js
@@ -176,7 +176,6 @@ class KeyboardInfo extends React.Component {
               <UploadDialog
                 onClose={this.cleanupUpload}
                 onDisconnect={this.props.onDisconnect}
-                onSuccess={this.props.onDisconnect}
                 toggleFlashing={this.props.toggleFlashing}
                 filename={this.state.firmwareFile}
                 open={this.state.uploadInitiated}


### PR DESCRIPTION
Reset the keyboard ourselves, with higher timeouts than `AvrGirl`. This seems to help with flashing failing at the post-reset stage, thus fixes #93.

We also go back to the keyboard selection page with a success message after a successful flash, the `SaveChangesButton` thus does not have time to revert back to active. This fixes #94.
