### PR TITLE
KeyboardInfo: Handle errors from focus.command("version")

### DIFF
--- a/src/renderer/components/KeyboardInfo.js
+++ b/src/renderer/components/KeyboardInfo.js
@@ -70,7 +70,11 @@ class KeyboardInfo extends React.Component {
     await this.setState({ inProgress: true });
 
     let focus = new Focus(),
+      version = "";
+
+    try {
       version = await focus.command("version");
+    } catch (e ) {} // eslint-disable-line
 
     this.setState({
       version: version,


### PR DESCRIPTION
When querying the version and Focus throws an error, catch that, so we can disable the progress bar.

Fixes #84.
