### PR TITLE
App: Use the default timeout for Focus

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -37,7 +37,6 @@ focus.addCommands({
   keymap: keymap,
   colormap: colormap
 });
-focus.timeout = 15000;
 
 class App extends React.Component {
   state = {


### PR DESCRIPTION
Not needing the CDC patch anymore, we do not need such high (15s) timeouts, and
the default 5s should suffice.
