### PR TITLE
Progressbar fixes

### DIFF
--- a/src/renderer/screens/ColormapEditor.js
+++ b/src/renderer/screens/ColormapEditor.js
@@ -133,14 +133,6 @@ class ColormapEditor extends React.Component {
   }
 
   render() {
-    if (this.state.colorMap.length == 0) {
-      return (
-        <main>
-          <LinearProgress variant="query" />
-        </main>
-      );
-    }
-
     const { classes } = this.props;
 
     let tabs = this.state.colorMap.map((_, index) => {
@@ -176,6 +168,7 @@ class ColormapEditor extends React.Component {
             </Tabs>
           </Toolbar>
         </Portal>
+        {this.state.colorMap.length == 0 && <LinearProgress variant="query" />}
         <div className={classes.editor}>
           {colormap}
           <Palette

--- a/src/renderer/screens/ColormapEditor/Layer.js
+++ b/src/renderer/screens/ColormapEditor/Layer.js
@@ -27,12 +27,24 @@ const led_map = [
 
 class Layer extends React.Component {
   render() {
-    if (!this.props.colormap || !this.props.palette) return null;
+    const colormap =
+      this.props.colormap ||
+      Array(64)
+        .fill()
+        .map(() => 0);
+    const palette =
+      this.props.palette.length > 0
+        ? this.props.palette
+        : Array(16)
+            .fill()
+            .map(() => ({
+              rgb: "#000000"
+            }));
 
     let getColor = (row, col) => {
       let ledIndex = led_map[parseInt(row)][parseInt(col)],
-        colorIndex = this.props.colormap[ledIndex],
-        color = this.props.palette[colorIndex].rgb;
+        colorIndex = colormap[ledIndex],
+        color = palette[colorIndex].rgb;
 
       return color;
     };

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -218,18 +218,20 @@ class LayoutEditor extends React.Component {
             >
               {tabs}
             </Tabs>
-            <FormControl>
-              <Select
-                value={this.state.defaultLayer}
-                onChange={this.onDefaultLayerChange}
-                displayEmpty
-              >
-                {layerMenu}
-              </Select>
-              <FormHelperText className={classes.selectDefaultLayer}>
-                Default layer
-              </FormHelperText>
-            </FormControl>
+            {this.state.keymap.length > 0 && (
+              <FormControl>
+                <Select
+                  value={this.state.defaultLayer}
+                  onChange={this.onDefaultLayerChange}
+                  displayEmpty
+                >
+                  {layerMenu}
+                </Select>
+                <FormHelperText className={classes.selectDefaultLayer}>
+                  Default layer
+                </FormHelperText>
+              </FormControl>
+            )}
           </Toolbar>
         </Portal>
         {this.state.keymap.length == 0 && <LinearProgress variant="query" />}

--- a/src/renderer/screens/LayoutEditor.js
+++ b/src/renderer/screens/LayoutEditor.js
@@ -165,14 +165,6 @@ class LayoutEditor extends React.Component {
   }
 
   render() {
-    if (this.state.keymap.length == 0) {
-      return (
-        <main>
-          <LinearProgress variant="query" />
-        </main>
-      );
-    }
-
     const { classes } = this.props;
     let focus = new Focus();
     const Layer = focus.device.components.keymap;
@@ -220,7 +212,7 @@ class LayoutEditor extends React.Component {
             <Tabs
               className={classes.tabs}
               value={this.state.currentLayer}
-              scrollable
+              scrollable={this.state.keymap.length != 0}
               scrollButtons="auto"
               onChange={this.selectLayer}
             >
@@ -240,6 +232,7 @@ class LayoutEditor extends React.Component {
             </FormControl>
           </Toolbar>
         </Portal>
+        {this.state.keymap.length == 0 && <LinearProgress variant="query" />}
         <div className={classes.editor}>
           {layer}
           <div className={classes.editorControls}>


### PR DESCRIPTION
With the last big UI overhaul, the progress bars on the editor screens were broken (they stopped being displayed). This restores them, and even improves the experience: we now show an empty keymap/colormap while loading, with a progressbar attached to the bottom of the appbar.

![screenshot from 2019-01-04 13-29-00](https://user-images.githubusercontent.com/17243/50688208-b8fd8400-1024-11e9-8aff-f49d36307475.png)
