### PR TITLE
main: Catch the gpu-process-crashed event, and print a message

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -96,3 +96,21 @@ app.on("ready", async () => {
 
   mainWindow = createMainWindow();
 });
+
+app.on("gpu-process-crashed", () => {
+  console.error(`
+*********************************************************************
+* Unfortunately the renderer process has crashed.                   *
+*                                                                   *
+* Please set the ELECTRON_ENABLE_LOGGING environment variable       *
+* to "1", and re-run the application from a terminal or console,    *
+* and submit the output to our issue tracker at:                    *
+*  https://github.com/keyboardio/chrysalis-bundle-keyboardio/issues *
+*                                                                   *
+* Thank you!                                                        *
+*********************************************************************
+`);
+  setTimeout(() => {
+    app.exit(1);
+  }, 5000);
+});


### PR DESCRIPTION
If, for some reason, the renderer process crashes, we can't display a proper error message in the browser window, so log one to the terminal with a few instructions about how to file a useful bug report about it.

This does not fix #112, but in the event of a similar bug occurring, we'll have more clue and more information to start with.
