### PR TITLE
SaveChangesButton: Make it fixed

### DIFF
--- a/src/renderer/components/SaveChangesButton.js
+++ b/src/renderer/components/SaveChangesButton.js
@@ -65,10 +65,10 @@ const styles = theme => ({
     backgroundColor: "#ddd !important"
   },
   fab: {
-    position: "static",
+    position: "fixed",
     justifyContent: "flex-end",
-    marginBottom: theme.spacing.unit * 2,
-    marginRight: theme.spacing.unit * 2
+    bottom: 0,
+    right: 0
   }
 });
 


### PR DESCRIPTION
In the end, we want the button to be floating, ie, fixed to the bottom right corner of the screen, no matter what.

This is still not ideal, but marginally better than the current behaviour.