### PR TITLE
Support FirmwareUpdate & Welcome for non-Kaleidoscope firmware

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,13 @@ The user interface underwent a major overhaul, in an attempt to follow the Mater
 
  [prs:116]: https://github.com/keyboardio/chrysalis-bundle-keyboardio/pull/116
 
+## Hardware support
+
+Chrysalis now supports the same hardware it did in previous versions, but it no
+longer requires a Kaleidoscope-based firmware to be present. For devices that
+come with different firmware, Chrysalis will detect them, and offer to flash a
+reasonable, Kaleidoscope-based and Chrysalis-ready default.
+
 Chrysalis 0.2.0
 ===============
 Released on 2018-12-31

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -100,6 +100,7 @@ class App extends React.Component {
       boardAnchor: null,
       pageMenu: false,
       connected: false,
+      device: null,
       pages: {},
       Page: KeyboardSelect
     };
@@ -125,6 +126,7 @@ class App extends React.Component {
         focus.close();
         this.setState({
           connected: false,
+          device: null,
           pages: {},
           Page: KeyboardSelect
         });
@@ -137,6 +139,7 @@ class App extends React.Component {
     if (!this.flashing) {
       this.setState({
         connected: false,
+        device: null,
         pages: {},
         Page: KeyboardSelect
       });
@@ -145,6 +148,16 @@ class App extends React.Component {
 
   onKeyboardConnect = async port => {
     focus.close();
+
+    if (!port.comName) {
+      this.setState({
+        connected: true,
+        pages: {},
+        Page: Welcome,
+        device: port.device
+      });
+      return;
+    }
 
     console.log("Connecting to", port.comName);
     await focus.open(port.comName, port.device);
@@ -163,6 +176,7 @@ class App extends React.Component {
 
     this.setState({
       connected: true,
+      device: null,
       pages: {
         keymap: commands.includes("keymap.map") > 0,
         colormap:
@@ -177,6 +191,7 @@ class App extends React.Component {
     focus.close();
     this.setState({
       connected: false,
+      device: null,
       pages: {},
       Page: KeyboardSelect
     });
@@ -216,7 +231,9 @@ class App extends React.Component {
     const { connected, pages, Page } = this.state;
 
     let focus = new Focus(),
-      device = focus.device && focus.device.info;
+      device =
+        (focus.device && focus.device.info) ||
+        (this.state.device && this.state.device.info);
 
     const { boardAnchor } = this.state;
     const boardOpen = Boolean(boardAnchor);
@@ -232,9 +249,7 @@ class App extends React.Component {
       });
     const boardMenu = boardMenuItems && (
       <Menu anchorEl={boardAnchor} open={boardOpen} onClose={this.boardClose}>
-        <MenuItem disabled>
-          {device.vendor} {device.product}
-        </MenuItem>
+        <MenuItem disabled>{device.displayName}</MenuItem>
         <Divider variant="middle" />
         {boardMenuItems}
       </Menu>
@@ -407,6 +422,7 @@ class App extends React.Component {
         </AppBar>
         <main className={classes.content}>
           <Page
+            device={this.state.device}
             appBarElement={() => document.querySelector("#appbar")}
             titleElement={() => document.querySelector("#page-title")}
             onConnect={this.onKeyboardConnect}

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -58,10 +58,17 @@ const styles = theme => ({
 });
 
 class FirmwareUpdate extends React.Component {
-  state = {
-    anchorEl: null,
-    firmwareFilename: ""
-  };
+  constructor(props) {
+    super(props);
+
+    let focus = new Focus();
+
+    this.state = {
+      anchorEl: null,
+      firmwareFilename: "",
+      device: props.device || focus.device
+    };
+  }
 
   openFirmwareMenu = event => {
     this.setState({ anchorEl: event.currentTarget });
@@ -102,8 +109,7 @@ class FirmwareUpdate extends React.Component {
   };
 
   _defaultFirmwareFilename = () => {
-    let focus = new Focus();
-    const { vendor, product } = focus.device.info;
+    const { vendor, product } = this.state.device.info;
     return path.join(getStaticPath(), vendor, product, "default.hex");
   };
 
@@ -112,7 +118,7 @@ class FirmwareUpdate extends React.Component {
     const filename =
       this.props.firmwareFilename || this._defaultFirmwareFilename();
 
-    return focus.device.flash(focus._port, filename);
+    return this.state.device.flash(focus._port, filename);
   };
 
   upload = async () => {
@@ -152,8 +158,6 @@ class FirmwareUpdate extends React.Component {
       filename = filename[filename.length - 1];
     }
 
-    let focus = new Focus();
-
     const defaultFirmwareItem = (
       <MenuItem
         selected={firmwareFilename == ""}
@@ -187,7 +191,7 @@ class FirmwareUpdate extends React.Component {
               {
                 "Updating the firmware is a safe process, it's very hard to brick your keyboard even with bad firmware, as most keyboards provide a way to go stay in bootloader mode, where new firmware can be flashed. Nevertheless, updating the firmware will overwrite the previous one. If you customised your firmware, make sure you're flashing one that you are comfortable with. "
               }
-              {focus.device.messages.preFlash}
+              {this.state.device.messages.preFlash}
             </Typography>
             <Typography component="p">
               {

--- a/src/renderer/screens/Welcome.js
+++ b/src/renderer/screens/Welcome.js
@@ -62,6 +62,8 @@ class Welcome extends React.Component {
     let focus = new Focus();
     const { classes } = this.props;
 
+    const device = this.props.device || focus.device;
+
     return (
       <div className={classes.root}>
         <Portal container={this.props.titleElement}>
@@ -74,8 +76,8 @@ class Welcome extends React.Component {
                 <KeyboardIcon />
               </Avatar>
             }
-            title={focus.device.info.displayName}
-            subheader={focus._port.path}
+            title={device.info.displayName}
+            subheader={focus._port && focus._port.path}
           />
           <CardContent>
             <Typography component="p" gutterBottom>


### PR DESCRIPTION
We support a number of keyboards that do not come with Kaleidoscope by default, and their factory firmware doesn't have a virtual serial port enabled either. We weren't able to find these previously, making it that much harder to try Chrysalis with a supported device.

With this change, we do a second pass of search, for keyboards that aren't Kaleidoscope-powered out of the factory, and find them via the `usb` library. For these boards, we do not really "connect" to them, just set things up well enough for the `FirmwareUpdate` and `Welcome` screens to work. This in turn allows one to flash a Kaleidoscope-based firmware onto these boards, and try Chrysalis.

We do make an assumption that all connected keyboards are unique, that we do not have two of the same keyboard attached at the same time.

Fixes #106.

![screenshot from 2019-01-05 23-46-01](https://user-images.githubusercontent.com/17243/50730035-408de480-1144-11e9-8878-5127ad267981.png)
![screenshot from 2019-01-05 23-46-21](https://user-images.githubusercontent.com/17243/50730041-4388d500-1144-11e9-8fc3-6f1feffa8642.png)
![screenshot from 2019-01-05 23-46-27](https://user-images.githubusercontent.com/17243/50730042-45eb2f00-1144-11e9-93b3-a95392044284.png)
