### PR TITLE
KeySelector: Add support for moddable keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ The user interface underwent a major overhaul, in an attempt to follow the Mater
 
  [prs:116]: https://github.com/keyboardio/chrysalis-bundle-keyboardio/pull/116
 
+## New features
+
+It is now possible to augment keys with modifiers, to have a key that sends -
+for example - `Shift+2`. We had the UI in place for this, but not the supporting
+code. We now have both.
+
 ## Hardware support
 
 Chrysalis now supports the same hardware it did in previous versions, but it no

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@chrysalis-api/hardware-ez-ergodox": "~0.0.2",
     "@chrysalis-api/hardware-keyboardio-model01": "~0.0.11",
     "@chrysalis-api/hardware-technomancy-atreus": "~0.0.4",
-    "@chrysalis-api/keymap": "~0.0.10",
+    "@chrysalis-api/keymap": "~0.0.11",
     "@material-ui/core": "^3.6.0",
     "@material-ui/icons": "^3.0.1",
     "@material-ui/lab": "^3.0.0-alpha.25",

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -214,6 +214,7 @@ class KeyGroupListUnwrapped extends React.Component {
       modSelector = (
         <FormGroup row>
           <FormControlLabel
+            disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & CTRL_HELD)}
@@ -221,6 +222,7 @@ class KeyGroupListUnwrapped extends React.Component {
             label="Control"
           />
           <FormControlLabel
+            disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & SHIFT_HELD)}
@@ -228,6 +230,7 @@ class KeyGroupListUnwrapped extends React.Component {
             label="Shift"
           />
           <FormControlLabel
+            disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & LALT_HELD)}
@@ -235,6 +238,7 @@ class KeyGroupListUnwrapped extends React.Component {
             label="Alt"
           />
           <FormControlLabel
+            disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & RALT_HELD)}
@@ -242,6 +246,7 @@ class KeyGroupListUnwrapped extends React.Component {
             label="AltGr"
           />
           <FormControlLabel
+            disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & GUI_HELD)}

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -85,6 +85,7 @@ const moddableGroups = [
   "Digits",
   "Punctuation",
   "Spacing",
+  "Modifiers",
   "Navigation",
   "Fx keys",
   "Numpad"

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -63,6 +63,12 @@ const styles = theme => ({
   },
   typeSelector: {
     color: theme.palette.primary.main
+  },
+  checkbox: {
+    marginRight: theme.spacing.unit * 4
+  },
+  checkboxRoot: {
+    padding: "12px 4px 12px 12px"
   }
 });
 
@@ -207,31 +213,36 @@ class KeyGroupListUnwrapped extends React.Component {
       modSelector = (
         <FormGroup row>
           <FormControlLabel
-            control={<Checkbox />}
+            className={classes.checkbox}
+            control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & CTRL_HELD)}
             onChange={this.toggleMask(CTRL_HELD)}
             label="Control"
           />
           <FormControlLabel
-            control={<Checkbox />}
+            className={classes.checkbox}
+            control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & SHIFT_HELD)}
             onChange={this.toggleMask(SHIFT_HELD)}
             label="Shift"
           />
           <FormControlLabel
-            control={<Checkbox />}
+            className={classes.checkbox}
+            control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & LALT_HELD)}
             onChange={this.toggleMask(LALT_HELD)}
             label="Alt"
           />
           <FormControlLabel
-            control={<Checkbox />}
+            className={classes.checkbox}
+            control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & RALT_HELD)}
             onChange={this.toggleMask(RALT_HELD)}
             label="AltGr"
           />
           <FormControlLabel
-            control={<Checkbox />}
+            className={classes.checkbox}
+            control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
             checked={Boolean(selectedKey & GUI_HELD)}
             onChange={this.toggleMask(GUI_HELD)}
             label="Gui"

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -193,7 +193,8 @@ class KeyGroupListUnwrapped extends React.Component {
     } = this.props;
 
     const keyCode = withModifiers ? selectedKey % 256 : selectedKey;
-    const mask = withModifiers ? selectedKey - keyCode : 0;
+    const mask =
+      selectedKey == 65535 ? 0 : withModifiers ? selectedKey - keyCode : 0;
     const itemList = items || baseKeyCodeTable[group].keys;
 
     const keyList = itemList.map(key => {
@@ -217,7 +218,7 @@ class KeyGroupListUnwrapped extends React.Component {
             disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
-            checked={Boolean(selectedKey & CTRL_HELD)}
+            checked={Boolean(mask & CTRL_HELD)}
             onChange={this.toggleMask(CTRL_HELD)}
             label="Control"
           />
@@ -225,7 +226,7 @@ class KeyGroupListUnwrapped extends React.Component {
             disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
-            checked={Boolean(selectedKey & SHIFT_HELD)}
+            checked={Boolean(mask & SHIFT_HELD)}
             onChange={this.toggleMask(SHIFT_HELD)}
             label="Shift"
           />
@@ -233,7 +234,7 @@ class KeyGroupListUnwrapped extends React.Component {
             disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
-            checked={Boolean(selectedKey & LALT_HELD)}
+            checked={Boolean(mask & LALT_HELD)}
             onChange={this.toggleMask(LALT_HELD)}
             label="Alt"
           />
@@ -241,7 +242,7 @@ class KeyGroupListUnwrapped extends React.Component {
             disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
-            checked={Boolean(selectedKey & RALT_HELD)}
+            checked={Boolean(mask & RALT_HELD)}
             onChange={this.toggleMask(RALT_HELD)}
             label="AltGr"
           />
@@ -249,7 +250,7 @@ class KeyGroupListUnwrapped extends React.Component {
             disabled={disabled}
             className={classes.checkbox}
             control={<Checkbox classes={{ root: classes.checkboxRoot }} />}
-            checked={Boolean(selectedKey & GUI_HELD)}
+            checked={Boolean(mask & GUI_HELD)}
             onChange={this.toggleMask(GUI_HELD)}
             label="Gui"
           />

--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -140,14 +140,14 @@ class KeyGroupCodeUnwrapped extends React.Component {
 const KeyGroupCode = withStyles(styles)(KeyGroupCodeUnwrapped);
 
 const KeyButton = withStyles(styles)(props => {
-  const { keyInfo, selectedKey, onKeySelect, disabled } = props;
+  const { keyInfo, selected, onKeySelect, disabled, mask } = props;
 
   return (
     <Button
       className={props.classes.key}
-      color={keyInfo.code == selectedKey ? "primary" : "default"}
-      variant={keyInfo.code == selectedKey ? "contained" : "outlined"}
-      onClick={() => onKeySelect(keyInfo.code)}
+      color={selected ? "primary" : "default"}
+      variant={selected ? "contained" : "outlined"}
+      onClick={() => onKeySelect(keyInfo.code | mask)}
       disabled={disabled}
     >
       {keyInfo.labels.verbose || keyInfo.labels.primary}
@@ -155,50 +155,100 @@ const KeyButton = withStyles(styles)(props => {
   );
 });
 
-const KeyGroupList = withStyles(styles)(props => {
-  const {
-    group,
-    items,
-    selectedKey,
-    onKeySelect,
-    withModifiers,
-    disabled
-  } = props;
+const CTRL_HELD = (1 << 0) << 8;
+const LALT_HELD = (1 << 1) << 8;
+const RALT_HELD = (1 << 2) << 8;
+const SHIFT_HELD = (1 << 3) << 8;
+const GUI_HELD = (1 << 4) << 8;
 
-  const itemList = items || baseKeyCodeTable[group].keys;
+class KeyGroupListUnwrapped extends React.Component {
+  toggleMask = mask => {
+    return () => {
+      const { onKeySelect, selectedKey } = this.props;
 
-  const keyList = itemList.map(key => {
+      if (selectedKey & mask) {
+        onKeySelect(selectedKey & ~mask);
+      } else {
+        onKeySelect(selectedKey | mask);
+      }
+    };
+  };
+
+  render() {
+    const {
+      classes,
+      group,
+      items,
+      selectedKey,
+      onKeySelect,
+      withModifiers,
+      disabled
+    } = this.props;
+
+    const keyCode = withModifiers ? selectedKey % 256 : selectedKey;
+    const mask = withModifiers ? selectedKey - keyCode : 0;
+    const itemList = items || baseKeyCodeTable[group].keys;
+
+    const keyList = itemList.map(key => {
+      return (
+        <KeyButton
+          key={key.code}
+          disabled={disabled}
+          keyInfo={key}
+          selected={key.code == keyCode}
+          onKeySelect={onKeySelect}
+          mask={mask}
+        />
+      );
+    });
+
+    let modSelector;
+    if (withModifiers) {
+      modSelector = (
+        <FormGroup row>
+          <FormControlLabel
+            control={<Checkbox />}
+            checked={Boolean(selectedKey & CTRL_HELD)}
+            onChange={this.toggleMask(CTRL_HELD)}
+            label="Control"
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            checked={Boolean(selectedKey & SHIFT_HELD)}
+            onChange={this.toggleMask(SHIFT_HELD)}
+            label="Shift"
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            checked={Boolean(selectedKey & LALT_HELD)}
+            onChange={this.toggleMask(LALT_HELD)}
+            label="Alt"
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            checked={Boolean(selectedKey & RALT_HELD)}
+            onChange={this.toggleMask(RALT_HELD)}
+            label="AltGr"
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            checked={Boolean(selectedKey & GUI_HELD)}
+            onChange={this.toggleMask(GUI_HELD)}
+            label="Gui"
+          />
+        </FormGroup>
+      );
+    }
+
     return (
-      <KeyButton
-        key={key.code}
-        disabled={disabled}
-        keyInfo={key}
-        selectedKey={selectedKey}
-        onKeySelect={onKeySelect}
-      />
-    );
-  });
-
-  let modSelector;
-  if (withModifiers) {
-    modSelector = (
-      <FormGroup row>
-        <FormControlLabel control={<Checkbox />} label="Control" disabled />
-        <FormControlLabel control={<Checkbox />} label="Shift" disabled />
-        <FormControlLabel control={<Checkbox />} label="Alt" disabled />
-        <FormControlLabel control={<Checkbox />} label="Gui" disabled />
-        <FormControlLabel control={<Checkbox />} label="AltGr" disabled />
-      </FormGroup>
+      <React.Fragment>
+        <div className={classes.keylist}> {keyList} </div>
+        {modSelector}
+      </React.Fragment>
     );
   }
-
-  return (
-    <React.Fragment>
-      <div className={props.classes.keylist}> {keyList} </div>
-      {modSelector}
-    </React.Fragment>
-  );
-});
+}
+const KeyGroupList = withStyles(styles)(KeyGroupListUnwrapped);
 
 class KeyGroup extends React.Component {
   render() {
@@ -262,12 +312,19 @@ class KeySelector extends React.Component {
 
     if (currentKeyCode == -1) return null;
 
-    let groupIndex = selectedGroup;
+    let groupIndex = selectedGroup,
+      keyCode = currentKeyCode;
+
+    if (currentKeyCode >= 256 && currentKeyCode <= 8191) {
+      groupIndex = -1;
+      keyCode = keyCode % 256;
+    }
+
     if (groupIndex == -1) {
       groupIndex = keyGroups.length - 1;
       baseKeyCodeTable.forEach((group, index) => {
         for (let key of group.keys) {
-          if (key.code == currentKeyCode) {
+          if (key.code == keyCode) {
             groupIndex = index;
             break;
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,10 +889,10 @@
     "@chrysalis-api/flash" "^0.0.1"
     react "^16.5.2"
 
-"@chrysalis-api/keymap@~0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.10.tgz#051f187bee58db399a66f8aaceb67500d02bf963"
-  integrity sha512-DMjZb6FmcbYIaEQsEU7suuY+yJ9lRyE5LwilUKQinbJ3a+r72pZOssUsZRAAzSgBEeMICjvih6+wnvvS+AcKNw==
+"@chrysalis-api/keymap@~0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@chrysalis-api/keymap/-/keymap-0.0.11.tgz#328d99113a2e8a444cf61522dd4e7809ddc626df"
+  integrity sha512-vq3/7LJVuG5c0K9g9uzfdc0qwvb16iXIApf4OvPxmOR5iXhxKJ0GXo5ruqWWZ1EDaVsO4vulFDKXoqihKHdKGw==
   dependencies:
     "@chrysalis-api/focus" "~0.0.8"
 


### PR DESCRIPTION
When encountering a modded key (`LSHIFT()` & friends), display the un-modded group. In the key list, look at the keycode, and handle modifiers. When selecting a key via the buttons, apply the selected modifiers too.

In practice, this means we can toggle the modifiers on and off now, and this fixes #63.

![screenshot from 2019-01-06 08-12-35](https://user-images.githubusercontent.com/17243/50733263-efedaa00-118a-11e9-906c-991913319693.png)
