### PR TITLE
Use a monospace font for keys and key buttons

### DIFF
--- a/src/renderer/screens/LayoutEditor/KeySelector.js
+++ b/src/renderer/screens/LayoutEditor/KeySelector.js
@@ -45,6 +45,7 @@ const styles = theme => ({
     width: 225
   },
   key: {
+    fontFamily: "Input Mono, monospace",
     margin: theme.spacing.unit / 2,
     padding: "4px 8px",
     minWidth: "auto",

--- a/src/styles/keymap.css
+++ b/src/styles/keymap.css
@@ -20,7 +20,7 @@ button {
 }
 
 .layer {
-  font-family: "OpenSans-Bold", "Open Sans", "sans-serif";
+  font-family: "Input Mono", "monospace";
   font-size: 10px;
   font-weight: 700;
   min-width: 550px;
@@ -58,7 +58,6 @@ button {
 }
 
 .extraKey {
-  font-family: "SourceCodePro-Bold", "Source Code Pro", "monospace";
   font-size: 8px;
 }
 


### PR DESCRIPTION
Fixes #142.

![screenshot from 2019-01-06 14-24-10](https://user-images.githubusercontent.com/17243/50736514-c0589500-11be-11e9-8648-bbe3996f718b.png)
